### PR TITLE
added -c -config parser argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ The initial release of Markdown support focuses on the Italic syntax. Users can 
 
 ### Config Example
 
+```
 stylesheet = "../examples/txtToWeb/styles.css"
 
 lang = "en-US"
+```
 
 #### Usage Example:
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,26 @@
 ## Usage
 
 ### Requirements
+
 1. bash/zsh/wsl Terminal
 2. Python
 
 ### Installation
 
 1. Clone this repository to your local machine:
+
 ```bash
    git clone https://github.com/your-username/txtToWeb.git
 ```
+
 2. Navigate to the txtToWeb directory:
+
 ```bash
    cd txtToWeb
 ```
+
 3. Make it executable
+
 ```bash
     chmod +x txtToWeb.py
 ```
@@ -34,33 +40,41 @@
 ### Basic Usage
 
 To convert a single text file to HTML:
+
 ```bash
 ./txtToWeb.py <filename>
 ```
 
 To add a stylesheet to the file:
+
 ```bash
-./txtToWeb.py -s https://example.com/style.css <filename> 
+./txtToWeb.py -s https://example.com/style.css <filename>
 ```
 
 To convert all .txt and .md files in a directory:
+
 ```bash
 txtToWeb.py /path/to/directory
 ```
 
-
-
 To convert all .txt and .md files in a directory and include a CSS stylesheet:
+
 ```bash
 ./txtToWeb.py -s https://example.com/style.css /path/to/directory
 ```
 
+To use TOML config:
+
+```bash
+txtToWeb.py -c /path/to/config /path/to/directory or file
+```
+
 ### Flags
 
-* `--version` or `-v`: Display the tool's version.
-* `--stylesheet` or `-s`: Specify a URL to a CSS stylesheet to include in the HTML files.
-* `--help` or `-h`: Display usage information and available flags.
-
+- `--version` or `-v`: Display the tool's version.
+- `--stylesheet` or `-s`: Specify a URL to a CSS stylesheet to include in the HTML files.
+- `--help` or `-h`: Display usage information and available flags.
+- `--config` or `-c`: URL to a TOML config file to be used as a config for the HTML files.
 
 ## Markdown Support
 
@@ -70,11 +84,18 @@ As of the latest update, `txtToWeb` has incorporated support for converting Mark
 
 The initial release of Markdown support focuses on the Italic syntax. Users can now write text in Italics in their Markdown files, and `txtToWeb` will correctly convert it into HTML. The Italic text can be written by wrapping the desired text segment with either single asterisks `*` or single underscores `_`.
 
+### Config Example
+
+stylesheet = "../examples/txtToWeb/styles.css"
+
+lang = "en-US"
+
 #### Usage Example:
 
 Markdown Input:
+
 ```markdown
-This is an *italic* example.
+This is an _italic_ example.
 And this is another _italic_ example.
 ```
 
@@ -90,10 +111,13 @@ Generated HTML Output:
 By default, the tool generates HTML files in a txtToWeb directory in the current working directory. Each HTML file corresponds to a processed text file, with the original filename.
 
 ### Example
+
 Command:
+
 ```bash
 ./txtToWeb.py -s https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css test.txt
 ```
+
 Sample Input: [test.txt](examples/test.txt)
 
 Output: [test.html](examples/txtToWeb/test.html)
@@ -101,4 +125,5 @@ Output: [test.html](examples/txtToWeb/test.html)
 Output Hosted: [https://txttoweb.netlify.app/](https://txttoweb.netlify.app/)
 
 ### License
+
 This project is licensed under the GNU General Public License v3.0 License - see the [LICENSE](LICENSE) file for details.

--- a/txtToWeb.py
+++ b/txtToWeb.py
@@ -119,7 +119,7 @@ def main():
     if args.config:
         config_file_path = args.config
         try:
-            with open(config_file_path, "r") as config_file:
+            with open(config_file_path, "rb") as config_file:
                 config_data = tomli.load(config_file)
 
                 stylesheet_url = config_data.get("stylesheet", stylesheet_url)

--- a/txtToWeb.py
+++ b/txtToWeb.py
@@ -104,6 +104,11 @@ def main():
         default="en-CA",  # Default language is Canadian English
         help="Language code to be used in the lang attribute on the root element",
     )
+    parser.add_argument ( 
+        "--config",
+        "-c",
+        help="URL to a TOML config file to be used as a config for the HTML files",
+    )
 
     args = parser.parse_args()
     input_path = args.input_path

--- a/txtToWeb.py
+++ b/txtToWeb.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import shutil
 import re
+import tomli
 
 # Define the tool's version
 VERSION = "txtToWeb v0.1"
@@ -114,6 +115,17 @@ def main():
     input_path = args.input_path
     stylesheet_url = args.stylesheet
     lang_attribute = args.lang
+
+    if args.config:
+        config_file_path = args.config
+        try:
+            with open(config_file_path, "r") as config_file:
+                config_data = tomli.load(config_file)
+                
+                stylesheet_url = config_data.get("stylesheet", stylesheet_url)
+                lang_attribute = config_data.get("lang", lang_attribute)
+        except FileNotFoundError:
+            print(f"Config file not found: {config_file_path}")
 
     if os.path.isfile(input_path) and (input_path.endswith(".txt") or input_path.endswith(".md")) :
         if os.path.exists('til'):

--- a/txtToWeb.py
+++ b/txtToWeb.py
@@ -121,11 +121,13 @@ def main():
         try:
             with open(config_file_path, "r") as config_file:
                 config_data = tomli.load(config_file)
-                
+
                 stylesheet_url = config_data.get("stylesheet", stylesheet_url)
                 lang_attribute = config_data.get("lang", lang_attribute)
         except FileNotFoundError:
             print(f"Config file not found: {config_file_path}")
+        except tomli.TOMLDecodeError:
+            print(f"Error parsing the config file: {config_file_path}")
 
     if os.path.isfile(input_path) and (input_path.endswith(".txt") or input_path.endswith(".md")) :
         if os.path.exists('til'):


### PR DESCRIPTION
Acceptance criteria for the feature: 

- [x]  The -c or --config flags accept a file path to a TOML-based config file.
- [x]  If the file is missing, or can't be parsed as TOML, exit with an appropriate error message.
- [x]  If the -c or --config option is provided, ignore all other options (i.e., a config file overrides other options on the command line).
- [x] The program should ignore any options in the config file it doesn't recognize. For example, if the app doesn't support stylesheets, ignore a stylesheet property.
- [x] If the config file is missing any options, assume the usual defaults.
- [x] User is able to pass TOML file and it applies to HTML
